### PR TITLE
Update classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,11 +63,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
     ],
 )


### PR DESCRIPTION
v1.0.0 removes Python 2.7 and all 3.x versions below 3.6.