### PR TITLE
Drop support for Python interpreters < 3.7

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.8"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/py-ci.yml
+++ b/.github/workflows/py-ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ import sys
 from setuptools import setup, find_packages
 
 
+REQUIRES_PYTHON = ">=3.7.0"
+
 # Use repository Markdown README.md for PyPI long description
 try:
     with io.open("README.md", encoding="utf-8") as f:
@@ -53,6 +55,7 @@ setup(
     platforms=["any"],
     packages=find_packages("lib"),
     package_dir={"": "lib"},
+    python_requires=REQUIRES_PYTHON,
     install_requires=["gitpython", "fonttools"],
     entry_points={
         "console_scripts": ["font-v = fontv.app:main"],
@@ -66,9 +69,9 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38
+envlist = py310
 
 [testenv]
 passenv = TOXENV CI TRAVIS TRAVIS_*


### PR DESCRIPTION
Our fonttools dependency dropped support for Py < 3.7.  We will too so that we can continue to support dependency updates